### PR TITLE
Depend on mintsystem

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.7.2
 
 Package: mintdesktop
 Architecture: all
-Depends: python (>= 2.4), python (<< 3), mint-info, wmctrl
+Depends: python (>= 2.4), python (<< 3), mint-info, mintsystem, wmctrl
 Description: Desktop configuration tool
  Configures some aspects of the desktop. 


### PR DESCRIPTION
Because it uses https://github.com/linuxmint/mintsystem/blob/master/usr/share/glib-2.0/schemas/com.linuxmint.gschema.xml
