### PR TITLE
properly clean up old .desktop file from /etc

### DIFF
--- a/debian/maintscript
+++ b/debian/maintscript
@@ -1,0 +1,2 @@
+rm_conffile /etc/xdg/autostart/compiz-migrate-to-custom-profile.desktop 3.4.7~
+


### PR DESCRIPTION
one does not simply remove a file from /etc :)

now it will be actually removed from the system when the user upgrades
mintdesktop to 3.4.7. as for now, it stays in the autostart apps list,
causing a warning on MATE session start (as the binary has been removed
some time ago).