### PR TITLE
Add support for Mutter

### DIFF
--- a/usr/bin/window-manager-launcher
+++ b/usr/bin/window-manager-launcher
@@ -34,7 +34,7 @@ else:
 p = subprocess.Popen(['ps', '-u', str(os.getuid())], stdout=subprocess.PIPE)
 out, err = p.communicate()
 processes_found = False
-for process in ['compton', "marco", "xfwm4", "compiz", "metacity", "openbox", "awesome" ]:
+for process in ['compton', "marco", "xfwm4", "compiz", "mutter", "metacity", "openbox", "awesome" ]:
     for line in out.splitlines():
         pname = line.decode('utf-8').split()[-1]
         if process in pname:
@@ -78,6 +78,8 @@ elif wm == "xfwm4-compton":
     subprocess.Popen(["compton", "--backend", "glx", "--vsync", "opengl-swc"])
 elif wm == "compiz":
     subprocess.Popen(["compiz", "--replace"])
+elif wm == "mutter":
+    subprocess.Popen(["mutter", "--replace"])
 elif wm == "metacity":
     settings = Gio.Settings("org.gnome.metacity")
     settings.set_boolean("compositing-manager", False)
@@ -99,7 +101,7 @@ elif wm == "openbox-compton":
     time.sleep(2)
     subprocess.Popen(["compton", "--backend", "glx", "--vsync", "opengl-swc"])
 elif wm == "awesome":
-    # subprocess.call(["killall", "marco", "xfwm4", "compiz", "metacity", "openbox", "awesome"]) # Kill all other window managers that might possibly still be running
+    # subprocess.call(["killall", "marco", "xfwm4", "compiz", "mutter", "metacity", "openbox", "awesome"]) # Kill all other window managers that might possibly still be running
     # time.sleep(0.1) # Wait some time until really all other window managers are killed otherwise awesome won't start up
     subprocess.Popen(["awesome"])
     if current_desktop == "MATE":  # The mate panel seems to move up a bit when starting awesome

--- a/usr/bin/wm-detect
+++ b/usr/bin/wm-detect
@@ -13,7 +13,7 @@ if "XDG_CURRENT_DESKTOP" in os.environ:
 wms = []
 p = subprocess.Popen(['ps', '-u', str(os.getuid())], stdout=subprocess.PIPE)
 out, err = p.communicate()
-for process in ['marco', 'metacity', 'xfwm4', 'compiz', 'openbox', 'compton']:
+for process in ['marco', 'metacity', 'xfwm4', 'mutter', 'compiz', 'openbox', 'compton']:
     for line in out.splitlines():
         pname = line.decode('utf-8').split()[-1]
         if process in pname:

--- a/usr/lib/linuxmint/mintdesktop/mintdesktop.py
+++ b/usr/lib/linuxmint/mintdesktop/mintdesktop.py
@@ -44,11 +44,14 @@ class MintDesktop:
         if self.marco_section is not None:
             self.marco_section.hide()
         self.metacity_section.hide()
+        self.mutter_section.hide()
         self.compiz_section.hide()
         if "marco" in wm:
             self.marco_section.show()
         elif "metacity" in wm:
             self.metacity_section.show()
+        elif "mutter" in wm:
+            self.mutter_section.show()
         elif "compiz" in wm and os.path.exists("/usr/bin/ccsm"):
             self.compiz_section.show()
             self.compiz_reset_button.set_sensitive(os.path.exists(self.compiz_path))
@@ -161,6 +164,8 @@ class MintDesktop:
             options.append(["openbox", _("Openbox")])
             if compton:
                 options.append(["openbox-compton", _("Openbox + Compton")])
+        if os.path.exists("/usr/bin/mutter"):
+            options.append(["mutter", _("Mutter")])
         if os.path.exists("/usr/bin/compiz"):
             options.append(["compiz", _("Compiz")])
         if os.path.exists("/usr/bin/awesome"):
@@ -195,7 +200,15 @@ class MintDesktop:
 
         self.metacity_section = page.add_section(_("Metacity settings"))
         self.metacity_section.add_row(GSettingsSwitch(_("Use system font in titlebar"), "org.gnome.desktop.wm.preferences", "titlebar-uses-system-font"))
+        self.metacity_section.add_row(GSettingsSwitch(_("Don't show window content while dragging them"), "org.gnome.metacity", "reduced-resources"))
         self.metacity_section.add_row(GSettingsComboBox(_("Buttons layout:"), "org.gnome.desktop.wm.preferences", "button-layout", button_options, size_group=size_group))
+
+        self.mutter_section = page.add_section(_("Mutter settings"))
+        self.mutter_section.add_row(GSettingsSwitch(_("Use system font in titlebar"), "org.gnome.desktop.wm.preferences", "titlebar-uses-system-font"))
+        self.mutter_section.add_row(GSettingsSwitch(_("Place new windows in the center of the screen"), "org.gnome.mutter", "center-new-windows"))
+        self.mutter_section.add_row(GSettingsSwitch(_("Automatically maximize nearly screen sized windows"), "org.gnome.mutter", "auto-maximize"))
+        self.mutter_section.add_row(GSettingsSwitch(_("Enable edge tiling when dropping windows on screen edges"), "org.gnome.mutter", "edge-tiling"))
+        self.mutter_section.add_row(GSettingsComboBox(_("Buttons layout:"), "org.gnome.desktop.wm.preferences", "button-layout", button_options, size_group=size_group))
 
         self.compiz_section = page.add_section(_("Compiz settings"))
 

--- a/usr/share/help/C/mintdesktop/wms.page
+++ b/usr/share/help/C/mintdesktop/wms.page
@@ -30,6 +30,12 @@
   </section>
 
   <section id="pros">
+    <title>Mutter</title>
+    <p>Mutter is the default window and compositing manager for the GNOME 3 desktop environment. It is very stable and very reliable.</p>
+    <p>If Mutter is not installed already, you can install it with <cmd>apt install mutter</cmd>.</p>
+  </section>
+
+  <section id="pros">
     <title>Xfwm4</title>
     <p>Xfwm4 is the default window manager for the Xfce desktop environment. It is very stable and very reliable. It can run with or without compositing.</p>
     <p>If Xfwm4 is not installed already, you can install it with <cmd>apt install xfwm4</cmd>.</p>


### PR DESCRIPTION
[Mutter](https://gitlab.gnome.org/GNOME/mutter) is a pretty good alternative to any combinations of Metacity+Compton, Marco+Compton or Xfwm4+Compton. It is well supported and as the evolution of Metacity, it is the default window manager for GNOME 3. IMHO it seems to be more stable w.r.t. compositing than Compton and, thus, could be preferred.