### PR TITLE
remove configobj dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,6 @@ Standards-Version: 3.9.5
 Package: mintdesktop
 Architecture: all
 Depends: python3 (>= 3.3),
-         python3-configobj,
          python3-xapp (>= 1.6),
          gir1.2-gdkpixbuf-2.0,
          gir1.2-glib-2.0,


### PR DESCRIPTION
not needed after 68ef0c7a565a124e416dadda84fea7de34e2f626